### PR TITLE
Fixed end listener not removing itself 

### DIFF
--- a/src/rcon.ts
+++ b/src/rcon.ts
@@ -131,7 +131,7 @@ export class Rcon {
         if (!this.socket.writable) throw new Error("End called twice")
         this.sendQueue.pause()
         this.socket.end()
-        await new Promise(resolve => this.on("end", resolve))
+        await new Promise(resolve => this.once("end", resolve))
     }
 
     /**


### PR DESCRIPTION
When calling end, the end listener (resolve) is not being removed and if you decide to open the connecting later and end it again, it will keep adding resolve listeners and after a while it will reach max event listener limit. this fixes it